### PR TITLE
Add REST API + OpenAPI spec for chatbot integration

### DIFF
--- a/api/rest.ts
+++ b/api/rest.ts
@@ -1,0 +1,39 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { handleRestRequest } from "../src/rest.js";
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  // CORS
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+
+  if (req.method === "OPTIONS") {
+    res.status(204).end();
+    return;
+  }
+
+  try {
+    // Strip /api/rest prefix to get the route path
+    const url = new URL(req.url || "/", `https://${req.headers.host || "localhost"}`);
+    const pathname = url.pathname.replace(/^\/api\/rest/, "") || "/";
+
+    // Build query params
+    const query: Record<string, string> = {};
+    url.searchParams.forEach((v, k) => { query[k] = v; });
+
+    const result = await handleRestRequest({
+      method: req.method || "GET",
+      pathname,
+      body: req.body || {},
+      query,
+      headers: { authorization: req.headers.authorization },
+    });
+
+    res.status(result.status).json(result.data);
+  } catch (err) {
+    console.error("REST handler error:", err);
+    if (!res.headersSent) {
+      res.status(500).json({ error: "Internal server error" });
+    }
+  }
+}

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -4,6 +4,7 @@ import { createServer } from "./server.js";
 import { validateToken, extractBearerToken, createInviteCodes } from "./auth.js";
 import { getDb, migrate } from "./db.js";
 import { renderLanding } from "./landing.js";
+import { handleRestRequest } from "./rest.js";
 
 const PORT = parseInt(process.env.PORT || "3000");
 
@@ -16,7 +17,7 @@ console.log("Seeded invite codes:", codes);
 const httpServer = createHttpServer(async (req, res) => {
   // CORS
   res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
   res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, mcp-session-id");
 
   if (req.method === "OPTIONS") {
@@ -25,8 +26,9 @@ const httpServer = createHttpServer(async (req, res) => {
     return;
   }
 
-  // Landing page
   const parsedUrl = new URL(req.url || "/", `http://localhost:${PORT}`);
+
+  // Landing page
   if (parsedUrl.pathname === "/" || parsedUrl.pathname === "") {
     try {
       const lang = parsedUrl.searchParams.get("lang") === "en" ? "en" : "zh";
@@ -41,8 +43,49 @@ const httpServer = createHttpServer(async (req, res) => {
     return;
   }
 
-  // Only handle /mcp
-  if (req.url !== "/mcp") {
+  // REST API: /api/rest/*
+  if (parsedUrl.pathname.startsWith("/api/rest")) {
+    let body: Record<string, unknown> = {};
+    if (req.method === "POST" || req.method === "PUT") {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) {
+        chunks.push(chunk as Buffer);
+      }
+      try {
+        body = JSON.parse(Buffer.concat(chunks).toString());
+      } catch {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Invalid JSON" }));
+        return;
+      }
+    }
+
+    const query: Record<string, string> = {};
+    parsedUrl.searchParams.forEach((v, k) => { query[k] = v; });
+
+    try {
+      const pathname = parsedUrl.pathname.replace(/^\/api\/rest/, "") || "/";
+      const result = await handleRestRequest({
+        method: req.method || "GET",
+        pathname,
+        body,
+        query,
+        headers: { authorization: req.headers.authorization },
+      });
+      res.writeHead(result.status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(result.data));
+    } catch (err) {
+      console.error("REST error:", err);
+      if (!res.headersSent) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Internal server error" }));
+      }
+    }
+    return;
+  }
+
+  // MCP endpoint: /mcp
+  if (parsedUrl.pathname !== "/mcp") {
     res.writeHead(404);
     res.end("Not found");
     return;
@@ -100,5 +143,7 @@ const httpServer = createHttpServer(async (req, res) => {
 });
 
 httpServer.listen(PORT, () => {
-  console.log(`Data Coffee MCP server running at http://localhost:${PORT}/mcp`);
+  console.log(`Data Coffee server running at http://localhost:${PORT}`);
+  console.log(`  MCP endpoint: http://localhost:${PORT}/mcp`);
+  console.log(`  REST API:     http://localhost:${PORT}/api/rest/...`);
 });

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -1,0 +1,581 @@
+/** OpenAPI 3.1 specification for Data Coffee REST API */
+export function getOpenApiSpec(baseUrl: string) {
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: "Data Coffee API",
+      description:
+        "Data Coffee 是荷兰数据群（700人华人数据/AI社区）的社区匹配服务。成员可以注册身份、创建和加入 coffee session（线下/线上聚会）、发送私信和群消息。",
+      version: "0.1.0",
+    },
+    servers: [{ url: baseUrl }],
+    components: {
+      securitySchemes: {
+        BearerAuth: {
+          type: "http",
+          scheme: "bearer",
+          description: "注册时获得的 token（dc_xxx 格式），用于身份验证。",
+        },
+      },
+      schemas: {
+        Error: {
+          type: "object",
+          properties: {
+            error: { type: "string" },
+          },
+        },
+        Profile: {
+          type: "object",
+          properties: {
+            user_id: { type: "string" },
+            nickname: { type: "string" },
+            status: { type: "string", enum: ["pending", "active", "frozen"] },
+            city: { type: "string", nullable: true },
+            company: { type: "string", nullable: true },
+            role: { type: "string", nullable: true },
+            skills: { type: "array", items: { type: "string" } },
+            bio: { type: "string", nullable: true },
+            available: { type: "array", items: { type: "string" } },
+            languages: { type: "array", items: { type: "string" } },
+          },
+        },
+        CoffeeSummary: {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            topic: { type: "string" },
+            description: { type: "string", nullable: true },
+            creator: { type: "string" },
+            city: { type: "string" },
+            location: { type: "string", nullable: true },
+            scheduled_at: { type: "string", nullable: true, format: "date-time" },
+            participants: { type: "integer" },
+            max_size: { type: "integer" },
+            status: { type: "string", enum: ["open", "full", "confirmed", "completed", "cancelled"] },
+            tags: { type: "array", items: { type: "string" } },
+            created_at: { type: "string" },
+          },
+        },
+        CoffeeDetail: {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            topic: { type: "string" },
+            description: { type: "string", nullable: true },
+            creator: { type: "string" },
+            city: { type: "string" },
+            location: { type: "string", nullable: true },
+            scheduled_at: { type: "string", nullable: true, format: "date-time" },
+            max_size: { type: "integer" },
+            status: { type: "string" },
+            tags: { type: "array", items: { type: "string" } },
+            participants: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  nickname: { type: "string" },
+                  city: { type: "string", nullable: true },
+                  role: { type: "string", nullable: true },
+                  skills: { type: "array", items: { type: "string" } },
+                  participant_role: { type: "string", enum: ["creator", "participant"] },
+                },
+              },
+            },
+          },
+        },
+        Message: {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            type: { type: "string", enum: ["direct", "coffee", "system"] },
+            from: { type: "string" },
+            content: { type: "string" },
+            coffee_id: { type: "string" },
+            coffee_topic: { type: "string" },
+            reply_to: { type: "string" },
+            read: { type: "boolean" },
+            created_at: { type: "string" },
+          },
+        },
+      },
+    },
+    paths: {
+      "/profile/register": {
+        post: {
+          operationId: "profile_register",
+          summary: "注册新成员，返回身份验证 token",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["nickname", "bio"],
+                  properties: {
+                    nickname: { type: "string", description: "显示名称" },
+                    bio: { type: "string", description: "自我介绍（技能、角色、城市等）" },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            "201": {
+              description: "注册成功",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      user_id: { type: "string" },
+                      token: { type: "string", description: "保存此 token 用于后续认证" },
+                      message: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/profile": {
+        get: {
+          operationId: "profile_get",
+          summary: "按用户 ID 或昵称查询成员资料",
+          parameters: [
+            {
+              name: "query",
+              in: "query",
+              required: true,
+              schema: { type: "string" },
+              description: "用户 ID 或昵称（支持模糊匹配）",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "返回匹配的用户资料（单个或数组）",
+              content: {
+                "application/json": {
+                  schema: {
+                    oneOf: [
+                      { $ref: "#/components/schemas/Profile" },
+                      { type: "array", items: { $ref: "#/components/schemas/Profile" } },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+        put: {
+          operationId: "profile_update",
+          summary: "更新自己的资料",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    city: { type: "string", description: "城市（如 Amsterdam, Rotterdam）" },
+                    company: { type: "string", description: "公司或组织" },
+                    role: { type: "string", description: "职位" },
+                    skills: { type: "array", items: { type: "string" }, description: "技能列表" },
+                    bio: { type: "string", description: "更新自我介绍" },
+                    available: { type: "array", items: { type: "string" }, description: "可用时间段（如 weekday_evening, weekend）" },
+                    languages: { type: "array", items: { type: "string" }, description: "语言" },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "更新成功",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      success: { type: "boolean" },
+                      message: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+            "401": { description: "未认证", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+          },
+        },
+      },
+      "/admin/invite-codes": {
+        post: {
+          operationId: "admin_create_invite_codes",
+          summary: "生成邀请码（管理员）",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["count"],
+                  properties: {
+                    count: { type: "integer", minimum: 1, maximum: 50, description: "生成邀请码数量" },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            "201": {
+              description: "生成成功",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      codes: { type: "array", items: { type: "string" } },
+                      message: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+            "401": { description: "未认证", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+          },
+        },
+      },
+      "/coffee": {
+        post: {
+          operationId: "coffee_create",
+          summary: "创建 coffee session（聚会）",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["topic"],
+                  properties: {
+                    topic: { type: "string", description: "聚会话题" },
+                    description: { type: "string", description: "详细描述" },
+                    city: { type: "string", description: "城市（线下）；不填则为线上" },
+                    location: { type: "string", description: "具体地点或线上会议链接" },
+                    scheduled_at: { type: "string", format: "date-time", description: "计划时间（ISO 8601）" },
+                    max_size: { type: "integer", minimum: 0, default: 0, description: "最大参与人数（0=不限）" },
+                    tags: { type: "array", items: { type: "string" }, description: "标签" },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            "201": {
+              description: "创建成功",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      coffee_id: { type: "string" },
+                      topic: { type: "string" },
+                      status: { type: "string" },
+                      message: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+            "401": { description: "未认证", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+          },
+        },
+        get: {
+          operationId: "coffee_list",
+          summary: "浏览开放的 coffee session",
+          parameters: [
+            { name: "city", in: "query", schema: { type: "string" }, description: "按城市筛选" },
+            { name: "tag", in: "query", schema: { type: "string" }, description: "按标签筛选" },
+            { name: "limit", in: "query", schema: { type: "integer", minimum: 1, maximum: 50, default: 20 }, description: "最大返回数" },
+          ],
+          responses: {
+            "200": {
+              description: "Coffee 列表",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      coffees: { type: "array", items: { $ref: "#/components/schemas/CoffeeSummary" } },
+                      total: { type: "integer" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/coffee/{id}": {
+        get: {
+          operationId: "coffee_detail",
+          summary: "查看 coffee session 详情（含参与者列表）",
+          parameters: [
+            { name: "id", in: "path", required: true, schema: { type: "string" }, description: "Coffee ID" },
+          ],
+          responses: {
+            "200": {
+              description: "Coffee 详情",
+              content: { "application/json": { schema: { $ref: "#/components/schemas/CoffeeDetail" } } },
+            },
+          },
+        },
+        put: {
+          operationId: "coffee_update",
+          summary: "更新 coffee session（仅创建者）",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            { name: "id", in: "path", required: true, schema: { type: "string" }, description: "Coffee ID" },
+          ],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    topic: { type: "string" },
+                    description: { type: "string" },
+                    city: { type: "string" },
+                    location: { type: "string" },
+                    scheduled_at: { type: "string", format: "date-time" },
+                    max_size: { type: "integer", minimum: 0 },
+                    tags: { type: "array", items: { type: "string" } },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "更新成功",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      success: { type: "boolean" },
+                      message: { type: "string" },
+                      updated_fields: { type: "array", items: { type: "string" } },
+                    },
+                  },
+                },
+              },
+            },
+            "401": { description: "未认证", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+          },
+        },
+      },
+      "/coffee/{id}/join": {
+        post: {
+          operationId: "coffee_join",
+          summary: "加入一个开放的 coffee session",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            { name: "id", in: "path", required: true, schema: { type: "string" }, description: "Coffee ID" },
+          ],
+          responses: {
+            "200": {
+              description: "加入成功",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      success: { type: "boolean" },
+                      coffee_id: { type: "string" },
+                      topic: { type: "string" },
+                      message: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+            "401": { description: "未认证", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+          },
+        },
+      },
+      "/coffee/{id}/leave": {
+        post: {
+          operationId: "coffee_leave",
+          summary: "退出 coffee session（创建者不能退出）",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            { name: "id", in: "path", required: true, schema: { type: "string" }, description: "Coffee ID" },
+          ],
+          responses: {
+            "200": {
+              description: "退出成功",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      success: { type: "boolean" },
+                      message: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+            "401": { description: "未认证", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+          },
+        },
+      },
+      "/coffee/{id}/complete": {
+        post: {
+          operationId: "coffee_complete",
+          summary: "标记 coffee session 为已完成（仅创建者）",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            { name: "id", in: "path", required: true, schema: { type: "string" }, description: "Coffee ID" },
+          ],
+          responses: {
+            "200": {
+              description: "标记成功",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      success: { type: "boolean" },
+                      message: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+            "401": { description: "未认证", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+          },
+        },
+      },
+      "/message": {
+        post: {
+          operationId: "message_send",
+          summary: "发送私信（按昵称）或 coffee 群消息",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["content"],
+                  properties: {
+                    to: { type: "string", description: "收件人昵称（私信）" },
+                    coffee_id: { type: "string", description: "Coffee ID（群消息）" },
+                    content: { type: "string", description: "消息内容" },
+                    reply_to: { type: "string", description: "回复的消息 ID" },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            "201": {
+              description: "发送成功",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      message_id: { type: "string" },
+                      type: { type: "string", enum: ["direct", "coffee"] },
+                      to: { type: "string" },
+                      coffee_id: { type: "string" },
+                      message: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+            "401": { description: "未认证", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+          },
+        },
+      },
+      "/message/inbox": {
+        get: {
+          operationId: "message_inbox",
+          summary: "查看收件箱（私信、群消息、系统通知）",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            { name: "type", in: "query", schema: { type: "string", enum: ["direct", "coffee", "system", "all"], default: "all" }, description: "消息类型筛选" },
+            { name: "unread", in: "query", schema: { type: "boolean", default: false }, description: "仅未读" },
+            { name: "coffee_id", in: "query", schema: { type: "string" }, description: "指定 coffee 的消息" },
+            { name: "limit", in: "query", schema: { type: "integer", minimum: 1, maximum: 50, default: 20 }, description: "最大返回数" },
+          ],
+          responses: {
+            "200": {
+              description: "收件箱消息",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      messages: { type: "array", items: { $ref: "#/components/schemas/Message" } },
+                      total: { type: "integer" },
+                      unread_count: { type: "integer" },
+                    },
+                  },
+                },
+              },
+            },
+            "401": { description: "未认证", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+          },
+        },
+      },
+      "/message/read": {
+        post: {
+          operationId: "message_read",
+          summary: "标记消息为已读",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    message_id: { type: "string", description: "标记单条消息已读" },
+                    coffee_id: { type: "string", description: "标记某 coffee 全部消息已读" },
+                    all: { type: "boolean", description: "标记所有未读消息为已读" },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "标记成功",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      success: { type: "boolean" },
+                      marked_count: { type: "integer" },
+                    },
+                  },
+                },
+              },
+            },
+            "401": { description: "未认证", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+          },
+        },
+      },
+    },
+  };
+}

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -1,0 +1,186 @@
+import { profileRegister, profileGet, profileUpdate, adminCreateInviteCodes } from "./services/profile.js";
+import { coffeeCreate, coffeeList, coffeeJoin, coffeeDetail, coffeeLeave, coffeeUpdate, coffeeComplete } from "./services/coffee.js";
+import { messageSend, messageInbox, messageRead } from "./services/message.js";
+import { validateToken, extractBearerToken } from "./auth.js";
+import { migrate } from "./db.js";
+import { getOpenApiSpec } from "./openapi.js";
+
+let migrated = false;
+
+interface RestRequest {
+  method: string;
+  pathname: string;
+  body: Record<string, unknown>;
+  query: Record<string, string>;
+  headers: { authorization?: string };
+}
+
+interface RestResponse {
+  status: number;
+  data: unknown;
+}
+
+/** Extract userId from Authorization header, returns null if not authenticated */
+async function authenticate(headers: { authorization?: string }): Promise<string | null> {
+  const token = extractBearerToken(headers.authorization ?? null);
+  if (!token) return null;
+  const result = await validateToken(token);
+  return result?.userId ?? null;
+}
+
+/** Require authentication, returning an error response if not authenticated */
+function requireAuth(userId: string | null): RestResponse | null {
+  if (!userId) {
+    return { status: 401, data: { error: "Authentication required. Provide Bearer token in Authorization header." } };
+  }
+  return null;
+}
+
+/** Route a REST request to the appropriate service function */
+export async function handleRestRequest(req: RestRequest): Promise<RestResponse> {
+  if (!migrated) {
+    await migrate();
+    migrated = true;
+  }
+
+  const { method, pathname, body, query, headers } = req;
+  const userId = await authenticate(headers);
+
+  // Helper to match routes like /coffee/:id/join
+  const match = (m: string, pattern: string): Record<string, string> | null => {
+    if (method !== m) return null;
+    const patternParts = pattern.split("/");
+    const pathParts = pathname.split("/");
+    if (patternParts.length !== pathParts.length) return null;
+    const params: Record<string, string> = {};
+    for (let i = 0; i < patternParts.length; i++) {
+      if (patternParts[i].startsWith(":")) {
+        params[patternParts[i].slice(1)] = pathParts[i];
+      } else if (patternParts[i] !== pathParts[i]) {
+        return null;
+      }
+    }
+    return params;
+  };
+
+  let m: Record<string, string> | null;
+
+  // ── OpenAPI Spec ──
+
+  if ((m = match("GET", "/openapi.json"))) {
+    // Derive base URL from request context; caller can override via ?base_url=
+    const baseUrl = query.base_url || "";
+    return { status: 200, data: getOpenApiSpec(baseUrl) };
+  }
+
+  // ── Profile ──
+
+  if ((m = match("POST", "/profile/register"))) {
+    const data = await profileRegister({
+      nickname: body.nickname as string,
+      bio: body.bio as string,
+    });
+    return { status: 201, data };
+  }
+
+  if ((m = match("GET", "/profile"))) {
+    if (!query.query) return { status: 400, data: { error: "query parameter is required" } };
+    const data = await profileGet({ query: query.query });
+    return { status: 200, data };
+  }
+
+  if ((m = match("PUT", "/profile"))) {
+    const err = requireAuth(userId);
+    if (err) return err;
+    const data = await profileUpdate(body as any, userId!);
+    return { status: 200, data };
+  }
+
+  if ((m = match("POST", "/admin/invite-codes"))) {
+    const err = requireAuth(userId);
+    if (err) return err;
+    const data = await adminCreateInviteCodes({ count: body.count as number }, userId!);
+    return { status: 201, data };
+  }
+
+  // ── Coffee ──
+
+  if ((m = match("POST", "/coffee"))) {
+    const err = requireAuth(userId);
+    if (err) return err;
+    const data = await coffeeCreate(body as any, userId!);
+    return { status: 201, data };
+  }
+
+  if ((m = match("GET", "/coffee"))) {
+    const data = await coffeeList({
+      city: query.city,
+      tag: query.tag,
+      limit: query.limit ? parseInt(query.limit) : undefined,
+    });
+    return { status: 200, data };
+  }
+
+  if ((m = match("GET", "/coffee/:id"))) {
+    const data = await coffeeDetail({ coffee_id: m.id });
+    return { status: 200, data };
+  }
+
+  if ((m = match("PUT", "/coffee/:id"))) {
+    const err = requireAuth(userId);
+    if (err) return err;
+    const data = await coffeeUpdate({ coffee_id: m.id, ...body as any }, userId!);
+    return { status: 200, data };
+  }
+
+  if ((m = match("POST", "/coffee/:id/join"))) {
+    const err = requireAuth(userId);
+    if (err) return err;
+    const data = await coffeeJoin({ coffee_id: m.id }, userId!);
+    return { status: 200, data };
+  }
+
+  if ((m = match("POST", "/coffee/:id/leave"))) {
+    const err = requireAuth(userId);
+    if (err) return err;
+    const data = await coffeeLeave({ coffee_id: m.id }, userId!);
+    return { status: 200, data };
+  }
+
+  if ((m = match("POST", "/coffee/:id/complete"))) {
+    const err = requireAuth(userId);
+    if (err) return err;
+    const data = await coffeeComplete({ coffee_id: m.id }, userId!);
+    return { status: 200, data };
+  }
+
+  // ── Message ──
+
+  if ((m = match("POST", "/message"))) {
+    const err = requireAuth(userId);
+    if (err) return err;
+    const data = await messageSend(body as any, userId!);
+    return { status: 201, data };
+  }
+
+  if ((m = match("GET", "/message/inbox"))) {
+    const err = requireAuth(userId);
+    if (err) return err;
+    const data = await messageInbox({
+      type: (query.type as any) || undefined,
+      unread: query.unread === "true",
+      coffee_id: query.coffee_id,
+      limit: query.limit ? parseInt(query.limit) : undefined,
+    }, userId!);
+    return { status: 200, data };
+  }
+
+  if ((m = match("POST", "/message/read"))) {
+    const err = requireAuth(userId);
+    if (err) return err;
+    const data = await messageRead(body as any, userId!);
+    return { status: 200, data };
+  }
+
+  return { status: 404, data: { error: "Not found" } };
+}

--- a/src/services/coffee.ts
+++ b/src/services/coffee.ts
@@ -1,0 +1,308 @@
+import { getDb } from "../db.js";
+import { generateId } from "../auth.js";
+import { createSystemMessage } from "./message.js";
+
+export async function coffeeCreate(
+  params: {
+    topic: string;
+    description?: string;
+    city?: string;
+    location?: string;
+    scheduled_at?: string;
+    max_size?: number;
+    tags?: string[];
+  },
+  userId: string
+) {
+  const db = getDb();
+  const id = generateId("cof");
+
+  await db.execute({
+    sql: `INSERT INTO coffees (id, creator_id, topic, description, city, location, scheduled_at, max_size, tags)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      id,
+      userId,
+      params.topic,
+      params.description || null,
+      params.city || null,
+      params.location || null,
+      params.scheduled_at || null,
+      params.max_size ?? 0,
+      JSON.stringify(params.tags || []),
+    ],
+  });
+
+  // Creator auto-joins
+  await db.execute({
+    sql: "INSERT INTO coffee_participants (coffee_id, user_id, role) VALUES (?, ?, 'creator')",
+    args: [id, userId],
+  });
+
+  return {
+    coffee_id: id,
+    topic: params.topic,
+    status: "open",
+    message: "Coffee created! Others can join with coffee_join.",
+  };
+}
+
+export async function coffeeList(params: { city?: string; tag?: string; limit?: number }) {
+  const db = getDb();
+  const conditions = ["c.status IN ('open', 'full', 'confirmed')"];
+  const args: unknown[] = [];
+
+  conditions.push("(c.scheduled_at IS NULL OR c.scheduled_at > datetime('now'))");
+
+  if (params.city) {
+    conditions.push("LOWER(c.city) = LOWER(?)");
+    args.push(params.city);
+  }
+  if (params.tag) {
+    conditions.push("c.tags LIKE ?");
+    args.push(`%${params.tag}%`);
+  }
+
+  const limit = params.limit ?? 20;
+  args.push(limit);
+
+  const result = await db.execute({
+    sql: `SELECT c.*, u.nickname AS creator_name,
+            (SELECT COUNT(*) FROM coffee_participants cp WHERE cp.coffee_id = c.id) AS participant_count
+          FROM coffees c
+          JOIN users u ON c.creator_id = u.id
+          WHERE ${conditions.join(" AND ")}
+          ORDER BY CASE WHEN c.scheduled_at IS NOT NULL THEN 0 ELSE 1 END, c.scheduled_at ASC, c.created_at DESC
+          LIMIT ?`,
+    args: args as any[],
+  });
+
+  const coffees = result.rows.map((row) => ({
+    id: row.id,
+    topic: row.topic,
+    description: row.description,
+    creator: row.creator_name,
+    city: row.city || "online",
+    location: row.location,
+    scheduled_at: row.scheduled_at,
+    participants: row.participant_count,
+    max_size: row.max_size,
+    status: row.status,
+    tags: JSON.parse((row.tags as string) || "[]"),
+    created_at: row.created_at,
+  }));
+
+  return { coffees, total: coffees.length };
+}
+
+export async function coffeeJoin(params: { coffee_id: string }, userId: string) {
+  const db = getDb();
+
+  const coffee = await db.execute({
+    sql: "SELECT * FROM coffees WHERE id = ?",
+    args: [params.coffee_id],
+  });
+  if (coffee.rows.length === 0) {
+    return { error: "Coffee not found" };
+  }
+
+  const c = coffee.rows[0];
+  if (c.status !== "open") {
+    return { error: `Coffee is ${c.status}, cannot join` };
+  }
+
+  const existing = await db.execute({
+    sql: "SELECT 1 FROM coffee_participants WHERE coffee_id = ? AND user_id = ?",
+    args: [params.coffee_id, userId],
+  });
+  if (existing.rows.length > 0) {
+    return { error: "You already joined this coffee" };
+  }
+
+  if ((c.max_size as number) > 0) {
+    const count = await db.execute({
+      sql: "SELECT COUNT(*) as cnt FROM coffee_participants WHERE coffee_id = ?",
+      args: [params.coffee_id],
+    });
+    const current = count.rows[0].cnt as number;
+    if (current >= (c.max_size as number)) {
+      return { error: "Coffee is full" };
+    }
+
+    if (current + 1 >= (c.max_size as number)) {
+      await db.execute({
+        sql: "UPDATE coffees SET status = 'full' WHERE id = ?",
+        args: [params.coffee_id],
+      });
+    }
+  }
+
+  await db.execute({
+    sql: "INSERT INTO coffee_participants (coffee_id, user_id, role) VALUES (?, ?, 'participant')",
+    args: [params.coffee_id, userId],
+  });
+
+  const joiner = await db.execute({ sql: "SELECT nickname FROM users WHERE id = ?", args: [userId] });
+  const joinerName = joiner.rows[0]?.nickname || "Someone";
+  await createSystemMessage(c.creator_id as string, `${joinerName} 加入了你的 coffee「${c.topic}」`);
+
+  return {
+    success: true,
+    coffee_id: params.coffee_id,
+    topic: c.topic,
+    message: "You joined the coffee!",
+  };
+}
+
+export async function coffeeDetail(params: { coffee_id: string }) {
+  const db = getDb();
+
+  const coffee = await db.execute({
+    sql: `SELECT c.*, u.nickname AS creator_name
+          FROM coffees c JOIN users u ON c.creator_id = u.id
+          WHERE c.id = ?`,
+    args: [params.coffee_id],
+  });
+  if (coffee.rows.length === 0) {
+    return { error: "Coffee not found" };
+  }
+
+  const participants = await db.execute({
+    sql: `SELECT u.nickname, p.city, p.role AS job_role, p.skills, cp.role, cp.joined_at
+          FROM coffee_participants cp
+          JOIN users u ON cp.user_id = u.id
+          LEFT JOIN profiles p ON u.id = p.user_id
+          WHERE cp.coffee_id = ?`,
+    args: [params.coffee_id],
+  });
+
+  const c = coffee.rows[0];
+  return {
+    id: c.id,
+    topic: c.topic,
+    description: c.description,
+    creator: c.creator_name,
+    city: c.city || "online",
+    location: c.location,
+    scheduled_at: c.scheduled_at,
+    max_size: c.max_size,
+    status: c.status,
+    tags: JSON.parse((c.tags as string) || "[]"),
+    participants: participants.rows.map((p) => ({
+      nickname: p.nickname,
+      city: p.city,
+      role: p.job_role,
+      skills: JSON.parse((p.skills as string) || "[]"),
+      participant_role: p.role,
+    })),
+  };
+}
+
+export async function coffeeLeave(params: { coffee_id: string }, userId: string) {
+  const db = getDb();
+
+  const participation = await db.execute({
+    sql: "SELECT role FROM coffee_participants WHERE coffee_id = ? AND user_id = ?",
+    args: [params.coffee_id, userId],
+  });
+  if (participation.rows.length === 0) {
+    return { error: "You are not in this coffee" };
+  }
+  if (participation.rows[0].role === "creator") {
+    return { error: "Creator cannot leave. Use coffee_cancel instead." };
+  }
+
+  await db.execute({
+    sql: "DELETE FROM coffee_participants WHERE coffee_id = ? AND user_id = ?",
+    args: [params.coffee_id, userId],
+  });
+
+  await db.execute({
+    sql: "UPDATE coffees SET status = 'open' WHERE id = ? AND status = 'full'",
+    args: [params.coffee_id],
+  });
+
+  const coffee = await db.execute({ sql: "SELECT creator_id, topic FROM coffees WHERE id = ?", args: [params.coffee_id] });
+  if (coffee.rows.length > 0) {
+    const leaver = await db.execute({ sql: "SELECT nickname FROM users WHERE id = ?", args: [userId] });
+    const leaverName = leaver.rows[0]?.nickname || "Someone";
+    await createSystemMessage(coffee.rows[0].creator_id as string, `${leaverName} 退出了你的 coffee「${coffee.rows[0].topic}」`);
+  }
+
+  return { success: true, message: "You left the coffee" };
+}
+
+export async function coffeeUpdate(
+  params: {
+    coffee_id: string;
+    topic?: string;
+    description?: string;
+    city?: string;
+    location?: string;
+    scheduled_at?: string;
+    max_size?: number;
+    tags?: string[];
+  },
+  userId: string
+) {
+  const db = getDb();
+
+  const coffee = await db.execute({
+    sql: "SELECT * FROM coffees WHERE id = ? AND creator_id = ?",
+    args: [params.coffee_id, userId],
+  });
+  if (coffee.rows.length === 0) {
+    return { error: "Coffee not found or you are not the creator" };
+  }
+
+  const fields: string[] = [];
+  const args: unknown[] = [];
+
+  if (params.topic !== undefined) { fields.push("topic = ?"); args.push(params.topic); }
+  if (params.description !== undefined) { fields.push("description = ?"); args.push(params.description); }
+  if (params.city !== undefined) { fields.push("city = ?"); args.push(params.city); }
+  if (params.location !== undefined) { fields.push("location = ?"); args.push(params.location); }
+  if (params.scheduled_at !== undefined) { fields.push("scheduled_at = ?"); args.push(params.scheduled_at); }
+  if (params.max_size !== undefined) { fields.push("max_size = ?"); args.push(params.max_size); }
+  if (params.tags !== undefined) { fields.push("tags = ?"); args.push(JSON.stringify(params.tags)); }
+
+  if (fields.length === 0) {
+    return { error: "No fields to update" };
+  }
+
+  args.push(params.coffee_id);
+  await db.execute({
+    sql: `UPDATE coffees SET ${fields.join(", ")} WHERE id = ?`,
+    args: args as any[],
+  });
+
+  return { success: true, message: "Coffee updated", updated_fields: fields.map(f => f.split(" =")[0]) };
+}
+
+export async function coffeeComplete(params: { coffee_id: string }, userId: string) {
+  const db = getDb();
+
+  const coffeeInfo = await db.execute({
+    sql: "SELECT topic FROM coffees WHERE id = ? AND creator_id = ?",
+    args: [params.coffee_id, userId],
+  });
+  if (coffeeInfo.rows.length === 0) {
+    return { error: "Coffee not found or you are not the creator" };
+  }
+
+  await db.execute({
+    sql: "UPDATE coffees SET status = 'completed' WHERE id = ?",
+    args: [params.coffee_id],
+  });
+
+  const participants = await db.execute({
+    sql: "SELECT user_id FROM coffee_participants WHERE coffee_id = ? AND user_id != ?",
+    args: [params.coffee_id, userId],
+  });
+  const topic = coffeeInfo.rows[0].topic as string;
+  for (const p of participants.rows) {
+    await createSystemMessage(p.user_id as string, `Coffee「${topic}」已完成，欢迎提交反馈`);
+  }
+
+  return { success: true, message: "Coffee marked as completed" };
+}

--- a/src/services/message.ts
+++ b/src/services/message.ts
@@ -1,0 +1,246 @@
+import { getDb } from "../db.js";
+import { generateId } from "../auth.js";
+
+/** Insert a system notification */
+export async function createSystemMessage(toUser: string, content: string): Promise<void> {
+  const db = getDb();
+  await db.execute({
+    sql: `INSERT INTO messages (id, type, from_user, to_user, content) VALUES (?, 'system', NULL, ?, ?)`,
+    args: [generateId("msg"), toUser, content],
+  });
+}
+
+export async function messageSend(
+  params: {
+    to?: string;
+    coffee_id?: string;
+    content: string;
+    reply_to?: string;
+  },
+  userId: string
+) {
+  if (!params.to && !params.coffee_id) {
+    return { error: "Either 'to' (nickname) or 'coffee_id' is required" };
+  }
+
+  const db = getDb();
+  const id = generateId("msg");
+
+  // Coffee group message
+  if (params.coffee_id) {
+    const membership = await db.execute({
+      sql: "SELECT 1 FROM coffee_participants WHERE coffee_id = ? AND user_id = ?",
+      args: [params.coffee_id, userId],
+    });
+    if (membership.rows.length === 0) {
+      return { error: "You are not a participant of this coffee" };
+    }
+
+    const coffee = await db.execute({
+      sql: "SELECT topic FROM coffees WHERE id = ?",
+      args: [params.coffee_id],
+    });
+    if (coffee.rows.length === 0) {
+      return { error: "Coffee not found" };
+    }
+
+    const participants = await db.execute({
+      sql: "SELECT COUNT(*) as cnt FROM coffee_participants WHERE coffee_id = ?",
+      args: [params.coffee_id],
+    });
+
+    await db.execute({
+      sql: `INSERT INTO messages (id, type, from_user, coffee_id, content, reply_to)
+            VALUES (?, 'coffee', ?, ?, ?, ?)`,
+      args: [id, userId, params.coffee_id, params.content, params.reply_to || null],
+    });
+
+    return {
+      message_id: id,
+      type: "coffee",
+      coffee_id: params.coffee_id,
+      coffee_topic: coffee.rows[0].topic,
+      participants: participants.rows[0].cnt,
+      message: `Message sent to coffee group (${participants.rows[0].cnt} participants)`,
+    };
+  }
+
+  // Direct message
+  const recipient = await db.execute({
+    sql: "SELECT id FROM users WHERE LOWER(nickname) = LOWER(?) AND status = 'active'",
+    args: [params.to!],
+  });
+  if (recipient.rows.length === 0) {
+    return { error: `User "${params.to}" not found` };
+  }
+
+  const toUserId = recipient.rows[0].id as string;
+  if (toUserId === userId) {
+    return { error: "Cannot send message to yourself" };
+  }
+
+  await db.execute({
+    sql: `INSERT INTO messages (id, type, from_user, to_user, content, reply_to)
+          VALUES (?, 'direct', ?, ?, ?, ?)`,
+    args: [id, userId, toUserId, params.content, params.reply_to || null],
+  });
+
+  const senderName = await db.execute({
+    sql: "SELECT nickname FROM users WHERE id = ?",
+    args: [userId],
+  });
+  const nickname = senderName.rows[0]?.nickname || "Someone";
+  await createSystemMessage(toUserId, `${nickname} 给你发了一条私信`);
+
+  return {
+    message_id: id,
+    type: "direct",
+    to: params.to,
+    message: `Message sent to ${params.to}`,
+  };
+}
+
+export async function messageInbox(
+  params: {
+    type?: "direct" | "coffee" | "system" | "all";
+    unread?: boolean;
+    coffee_id?: string;
+    limit?: number;
+  },
+  userId: string
+) {
+  const db = getDb();
+  const type = params.type ?? "all";
+  const limit = params.limit ?? 20;
+
+  const conditions: string[] = [];
+  const args: unknown[] = [];
+
+  if (params.coffee_id) {
+    conditions.push("m.type = 'coffee' AND m.coffee_id = ?");
+    args.push(params.coffee_id);
+  } else if (type === "direct") {
+    conditions.push("m.type = 'direct' AND m.to_user = ?");
+    args.push(userId);
+  } else if (type === "system") {
+    conditions.push("m.type = 'system' AND m.to_user = ?");
+    args.push(userId);
+  } else if (type === "coffee") {
+    conditions.push("m.type = 'coffee' AND m.coffee_id IN (SELECT coffee_id FROM coffee_participants WHERE user_id = ?)");
+    args.push(userId);
+  } else {
+    conditions.push(`(
+      (m.type = 'direct' AND m.to_user = ?) OR
+      (m.type = 'system' AND m.to_user = ?) OR
+      (m.type = 'coffee' AND m.coffee_id IN (SELECT coffee_id FROM coffee_participants WHERE user_id = ?))
+    )`);
+    args.push(userId, userId, userId);
+  }
+
+  conditions.push("NOT (m.type = 'coffee' AND m.from_user = ?)");
+  args.push(userId);
+
+  if (params.unread) {
+    conditions.push("mr.read_at IS NULL");
+  }
+
+  const whereClause = conditions.join(" AND ");
+
+  const unreadResult = await db.execute({
+    sql: `SELECT COUNT(*) as cnt FROM messages m
+          LEFT JOIN message_reads mr ON m.id = mr.message_id AND mr.user_id = ?
+          WHERE ${whereClause} AND mr.read_at IS NULL`,
+    args: [userId, ...args] as any[],
+  });
+
+  args.push(limit);
+  const result = await db.execute({
+    sql: `SELECT m.id, m.type, m.content, m.coffee_id, m.reply_to, m.created_at,
+                 u.nickname AS from_nickname,
+                 c.topic AS coffee_topic,
+                 CASE WHEN mr.read_at IS NOT NULL THEN 1 ELSE 0 END AS is_read
+          FROM messages m
+          LEFT JOIN users u ON m.from_user = u.id
+          LEFT JOIN coffees c ON m.coffee_id = c.id
+          LEFT JOIN message_reads mr ON m.id = mr.message_id AND mr.user_id = ?
+          WHERE ${whereClause}
+          ORDER BY m.created_at DESC
+          LIMIT ?`,
+    args: [userId, ...args] as any[],
+  });
+
+  const messages = result.rows.map((row) => ({
+    id: row.id,
+    type: row.type,
+    from: row.from_nickname || "system",
+    content: row.content,
+    coffee_id: row.coffee_id || undefined,
+    coffee_topic: row.coffee_topic || undefined,
+    reply_to: row.reply_to || undefined,
+    read: !!row.is_read,
+    created_at: row.created_at,
+  }));
+
+  return {
+    messages,
+    total: messages.length,
+    unread_count: unreadResult.rows[0].cnt,
+  };
+}
+
+export async function messageRead(
+  params: {
+    message_id?: string;
+    coffee_id?: string;
+    all?: boolean;
+  },
+  userId: string
+) {
+  if (!params.message_id && !params.coffee_id && !params.all) {
+    return { error: "Specify message_id, coffee_id, or all: true" };
+  }
+
+  const db = getDb();
+  let marked = 0;
+
+  if (params.message_id) {
+    const result = await db.execute({
+      sql: `INSERT OR IGNORE INTO message_reads (message_id, user_id) VALUES (?, ?)`,
+      args: [params.message_id, userId],
+    });
+    marked = result.rowsAffected;
+  } else if (params.coffee_id) {
+    const unread = await db.execute({
+      sql: `SELECT m.id FROM messages m
+            LEFT JOIN message_reads mr ON m.id = mr.message_id AND mr.user_id = ?
+            WHERE m.coffee_id = ? AND mr.read_at IS NULL`,
+      args: [userId, params.coffee_id],
+    });
+    for (const row of unread.rows) {
+      await db.execute({
+        sql: `INSERT OR IGNORE INTO message_reads (message_id, user_id) VALUES (?, ?)`,
+        args: [row.id, userId],
+      });
+    }
+    marked = unread.rows.length;
+  } else if (params.all) {
+    const unread = await db.execute({
+      sql: `SELECT m.id FROM messages m
+            LEFT JOIN message_reads mr ON m.id = mr.message_id AND mr.user_id = ?
+            WHERE mr.read_at IS NULL AND (
+              (m.to_user = ?) OR
+              (m.type = 'coffee' AND m.coffee_id IN (SELECT coffee_id FROM coffee_participants WHERE user_id = ?))
+            )`,
+      args: [userId, userId, userId],
+    });
+    for (const row of unread.rows) {
+      await db.execute({
+        sql: `INSERT OR IGNORE INTO message_reads (message_id, user_id) VALUES (?, ?)`,
+        args: [row.id, userId],
+      });
+    }
+    marked = unread.rows.length;
+  }
+
+  return { success: true, marked_count: marked };
+}

--- a/src/services/profile.ts
+++ b/src/services/profile.ts
@@ -1,0 +1,97 @@
+import { getDb } from "../db.js";
+import { generateToken, generateId, createInviteCodes } from "../auth.js";
+
+export async function profileRegister(params: { nickname: string; bio: string }) {
+  const db = getDb();
+  const id = generateId("u");
+  const token = generateToken();
+
+  await db.execute({
+    sql: "INSERT INTO users (id, nickname, token, invite_code, status) VALUES (?, ?, ?, ?, 'active')",
+    args: [id, params.nickname, token, "open"],
+  });
+
+  await db.execute({
+    sql: "INSERT INTO profiles (user_id, bio) VALUES (?, ?)",
+    args: [id, params.bio],
+  });
+
+  return {
+    user_id: id,
+    token,
+    message: "Registration successful. Save your token for future connections.",
+  };
+}
+
+export async function profileGet(params: { query: string }) {
+  const db = getDb();
+  const result = await db.execute({
+    sql: `SELECT u.id, u.nickname, u.status, p.city, p.company, p.role, p.skills, p.bio, p.available, p.languages, p.updated_at
+          FROM users u LEFT JOIN profiles p ON u.id = p.user_id
+          WHERE u.id = ? OR u.nickname LIKE ?`,
+    args: [params.query, `%${params.query}%`],
+  });
+
+  if (result.rows.length === 0) {
+    return { error: "User not found" };
+  }
+
+  const profiles = result.rows.map((row) => ({
+    user_id: row.id,
+    nickname: row.nickname,
+    status: row.status,
+    city: row.city,
+    company: row.company,
+    role: row.role,
+    skills: JSON.parse((row.skills as string) || "[]"),
+    bio: row.bio,
+    available: JSON.parse((row.available as string) || "[]"),
+    languages: JSON.parse((row.languages as string) || "[]"),
+  }));
+
+  return profiles.length === 1 ? profiles[0] : profiles;
+}
+
+export async function profileUpdate(
+  params: {
+    city?: string;
+    company?: string;
+    role?: string;
+    skills?: string[];
+    bio?: string;
+    available?: string[];
+    languages?: string[];
+  },
+  userId: string
+) {
+  const db = getDb();
+  const fields: string[] = [];
+  const values: unknown[] = [];
+
+  if (params.city !== undefined) { fields.push("city = ?"); values.push(params.city); }
+  if (params.company !== undefined) { fields.push("company = ?"); values.push(params.company); }
+  if (params.role !== undefined) { fields.push("role = ?"); values.push(params.role); }
+  if (params.skills !== undefined) { fields.push("skills = ?"); values.push(JSON.stringify(params.skills)); }
+  if (params.bio !== undefined) { fields.push("bio = ?"); values.push(params.bio); }
+  if (params.available !== undefined) { fields.push("available = ?"); values.push(JSON.stringify(params.available)); }
+  if (params.languages !== undefined) { fields.push("languages = ?"); values.push(JSON.stringify(params.languages)); }
+
+  if (fields.length === 0) {
+    return { error: "No fields to update" };
+  }
+
+  fields.push("updated_at = CURRENT_TIMESTAMP");
+  values.push(userId);
+
+  await db.execute({
+    sql: `UPDATE profiles SET ${fields.join(", ")} WHERE user_id = ?`,
+    args: values as any[],
+  });
+
+  return { success: true, message: "Profile updated" };
+}
+
+export async function adminCreateInviteCodes(params: { count: number }, userId: string | null) {
+  const codes = await createInviteCodes(params.count, userId);
+  return { codes, message: `Generated ${params.count} invite codes` };
+}

--- a/src/tools/coffee.ts
+++ b/src/tools/coffee.ts
@@ -1,8 +1,18 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { getDb } from "../db.js";
-import { generateId } from "../auth.js";
-import { createSystemMessage } from "./message.js";
+import {
+  coffeeCreate,
+  coffeeList,
+  coffeeJoin,
+  coffeeDetail,
+  coffeeLeave,
+  coffeeUpdate,
+  coffeeComplete,
+} from "../services/coffee.js";
+
+function jsonResult(data: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
+}
 
 export function registerCoffeeTools(server: McpServer) {
   server.tool(
@@ -19,48 +29,8 @@ export function registerCoffeeTools(server: McpServer) {
     },
     async (params, { authInfo }) => {
       const userId = (authInfo?.extra as { userId?: string })?.userId;
-      if (!userId) {
-        return { content: [{ type: "text", text: JSON.stringify({ error: "Authentication required" }) }] };
-      }
-
-      const db = getDb();
-      const id = generateId("cof");
-
-      await db.execute({
-        sql: `INSERT INTO coffees (id, creator_id, topic, description, city, location, scheduled_at, max_size, tags)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        args: [
-          id,
-          userId,
-          params.topic,
-          params.description || null,
-          params.city || null,
-          params.location || null,
-          params.scheduled_at || null,
-          params.max_size,
-          JSON.stringify(params.tags || []),
-        ],
-      });
-
-      // Creator auto-joins
-      await db.execute({
-        sql: "INSERT INTO coffee_participants (coffee_id, user_id, role) VALUES (?, ?, 'creator')",
-        args: [id, userId],
-      });
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify({
-              coffee_id: id,
-              topic: params.topic,
-              status: "open",
-              message: "Coffee created! Others can join with coffee_join.",
-            }),
-          },
-        ],
-      };
+      if (!userId) return jsonResult({ error: "Authentication required" });
+      return jsonResult(await coffeeCreate(params, userId));
     }
   );
 
@@ -72,53 +42,7 @@ export function registerCoffeeTools(server: McpServer) {
       tag: z.string().optional().describe("Filter by tag"),
       limit: z.number().min(1).max(50).default(20).describe("Max results"),
     },
-    async (params) => {
-      const db = getDb();
-      const conditions = ["c.status IN ('open', 'full', 'confirmed')"];
-      const args: unknown[] = [];
-
-      // Filter out past coffees (scheduled_at is in the past)
-      conditions.push("(c.scheduled_at IS NULL OR c.scheduled_at > datetime('now'))");
-
-      if (params.city) {
-        conditions.push("LOWER(c.city) = LOWER(?)");
-        args.push(params.city);
-      }
-      if (params.tag) {
-        conditions.push("c.tags LIKE ?");
-        args.push(`%${params.tag}%`);
-      }
-
-      args.push(params.limit);
-
-      const result = await db.execute({
-        sql: `SELECT c.*, u.nickname AS creator_name,
-                (SELECT COUNT(*) FROM coffee_participants cp WHERE cp.coffee_id = c.id) AS participant_count
-              FROM coffees c
-              JOIN users u ON c.creator_id = u.id
-              WHERE ${conditions.join(" AND ")}
-              ORDER BY CASE WHEN c.scheduled_at IS NOT NULL THEN 0 ELSE 1 END, c.scheduled_at ASC, c.created_at DESC
-              LIMIT ?`,
-        args: args as any[],
-      });
-
-      const coffees = result.rows.map((row) => ({
-        id: row.id,
-        topic: row.topic,
-        description: row.description,
-        creator: row.creator_name,
-        city: row.city || "online",
-        location: row.location,
-        scheduled_at: row.scheduled_at,
-        participants: row.participant_count,
-        max_size: row.max_size,
-        status: row.status,
-        tags: JSON.parse((row.tags as string) || "[]"),
-        created_at: row.created_at,
-      }));
-
-      return { content: [{ type: "text", text: JSON.stringify({ coffees, total: coffees.length }) }] };
-    }
+    async (params) => jsonResult(await coffeeList(params))
   );
 
   server.tool(
@@ -129,78 +53,8 @@ export function registerCoffeeTools(server: McpServer) {
     },
     async ({ coffee_id }, { authInfo }) => {
       const userId = (authInfo?.extra as { userId?: string })?.userId;
-      if (!userId) {
-        return { content: [{ type: "text", text: JSON.stringify({ error: "Authentication required" }) }] };
-      }
-
-      const db = getDb();
-
-      // Check coffee exists and is open
-      const coffee = await db.execute({
-        sql: "SELECT * FROM coffees WHERE id = ?",
-        args: [coffee_id],
-      });
-      if (coffee.rows.length === 0) {
-        return { content: [{ type: "text", text: JSON.stringify({ error: "Coffee not found" }) }] };
-      }
-
-      const c = coffee.rows[0];
-      if (c.status !== "open") {
-        return { content: [{ type: "text", text: JSON.stringify({ error: `Coffee is ${c.status}, cannot join` }) }] };
-      }
-
-      // Check not already joined
-      const existing = await db.execute({
-        sql: "SELECT 1 FROM coffee_participants WHERE coffee_id = ? AND user_id = ?",
-        args: [coffee_id, userId],
-      });
-      if (existing.rows.length > 0) {
-        return { content: [{ type: "text", text: JSON.stringify({ error: "You already joined this coffee" }) }] };
-      }
-
-      // Check capacity
-      if ((c.max_size as number) > 0) {
-        const count = await db.execute({
-          sql: "SELECT COUNT(*) as cnt FROM coffee_participants WHERE coffee_id = ?",
-          args: [coffee_id],
-        });
-        const current = count.rows[0].cnt as number;
-        if (current >= (c.max_size as number)) {
-          return { content: [{ type: "text", text: JSON.stringify({ error: "Coffee is full" }) }] };
-        }
-
-        // Auto-set to full if this is the last spot
-        if (current + 1 >= (c.max_size as number)) {
-          await db.execute({
-            sql: "UPDATE coffees SET status = 'full' WHERE id = ?",
-            args: [coffee_id],
-          });
-        }
-      }
-
-      await db.execute({
-        sql: "INSERT INTO coffee_participants (coffee_id, user_id, role) VALUES (?, ?, 'participant')",
-        args: [coffee_id, userId],
-      });
-
-      // Notify creator
-      const joiner = await db.execute({ sql: "SELECT nickname FROM users WHERE id = ?", args: [userId] });
-      const joinerName = joiner.rows[0]?.nickname || "Someone";
-      await createSystemMessage(c.creator_id as string, `${joinerName} 加入了你的 coffee「${c.topic}」`);
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify({
-              success: true,
-              coffee_id,
-              topic: c.topic,
-              message: "You joined the coffee!",
-            }),
-          },
-        ],
-      };
+      if (!userId) return jsonResult({ error: "Authentication required" });
+      return jsonResult(await coffeeJoin({ coffee_id }, userId));
     }
   );
 
@@ -210,56 +64,7 @@ export function registerCoffeeTools(server: McpServer) {
     {
       coffee_id: z.string().describe("ID of the coffee"),
     },
-    async ({ coffee_id }) => {
-      const db = getDb();
-
-      const coffee = await db.execute({
-        sql: `SELECT c.*, u.nickname AS creator_name
-              FROM coffees c JOIN users u ON c.creator_id = u.id
-              WHERE c.id = ?`,
-        args: [coffee_id],
-      });
-      if (coffee.rows.length === 0) {
-        return { content: [{ type: "text", text: JSON.stringify({ error: "Coffee not found" }) }] };
-      }
-
-      const participants = await db.execute({
-        sql: `SELECT u.nickname, p.city, p.role AS job_role, p.skills, cp.role, cp.joined_at
-              FROM coffee_participants cp
-              JOIN users u ON cp.user_id = u.id
-              LEFT JOIN profiles p ON u.id = p.user_id
-              WHERE cp.coffee_id = ?`,
-        args: [coffee_id],
-      });
-
-      const c = coffee.rows[0];
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify({
-              id: c.id,
-              topic: c.topic,
-              description: c.description,
-              creator: c.creator_name,
-              city: c.city || "online",
-              location: c.location,
-              scheduled_at: c.scheduled_at,
-              max_size: c.max_size,
-              status: c.status,
-              tags: JSON.parse((c.tags as string) || "[]"),
-              participants: participants.rows.map((p) => ({
-                nickname: p.nickname,
-                city: p.city,
-                role: p.job_role,
-                skills: JSON.parse((p.skills as string) || "[]"),
-                participant_role: p.role,
-              })),
-            }),
-          },
-        ],
-      };
-    }
+    async ({ coffee_id }) => jsonResult(await coffeeDetail({ coffee_id }))
   );
 
   server.tool(
@@ -270,43 +75,8 @@ export function registerCoffeeTools(server: McpServer) {
     },
     async ({ coffee_id }, { authInfo }) => {
       const userId = (authInfo?.extra as { userId?: string })?.userId;
-      if (!userId) {
-        return { content: [{ type: "text", text: JSON.stringify({ error: "Authentication required" }) }] };
-      }
-
-      const db = getDb();
-
-      const participation = await db.execute({
-        sql: "SELECT role FROM coffee_participants WHERE coffee_id = ? AND user_id = ?",
-        args: [coffee_id, userId],
-      });
-      if (participation.rows.length === 0) {
-        return { content: [{ type: "text", text: JSON.stringify({ error: "You are not in this coffee" }) }] };
-      }
-      if (participation.rows[0].role === "creator") {
-        return { content: [{ type: "text", text: JSON.stringify({ error: "Creator cannot leave. Use coffee_cancel instead." }) }] };
-      }
-
-      await db.execute({
-        sql: "DELETE FROM coffee_participants WHERE coffee_id = ? AND user_id = ?",
-        args: [coffee_id, userId],
-      });
-
-      // Reopen if was full
-      await db.execute({
-        sql: "UPDATE coffees SET status = 'open' WHERE id = ? AND status = 'full'",
-        args: [coffee_id],
-      });
-
-      // Notify creator
-      const coffee = await db.execute({ sql: "SELECT creator_id, topic FROM coffees WHERE id = ?", args: [coffee_id] });
-      if (coffee.rows.length > 0) {
-        const leaver = await db.execute({ sql: "SELECT nickname FROM users WHERE id = ?", args: [userId] });
-        const leaverName = leaver.rows[0]?.nickname || "Someone";
-        await createSystemMessage(coffee.rows[0].creator_id as string, `${leaverName} 退出了你的 coffee「${coffee.rows[0].topic}」`);
-      }
-
-      return { content: [{ type: "text", text: JSON.stringify({ success: true, message: "You left the coffee" }) }] };
+      if (!userId) return jsonResult({ error: "Authentication required" });
+      return jsonResult(await coffeeLeave({ coffee_id }, userId));
     }
   );
 
@@ -325,43 +95,8 @@ export function registerCoffeeTools(server: McpServer) {
     },
     async ({ coffee_id, ...updates }, { authInfo }) => {
       const userId = (authInfo?.extra as { userId?: string })?.userId;
-      if (!userId) {
-        return { content: [{ type: "text", text: JSON.stringify({ error: "Authentication required" }) }] };
-      }
-
-      const db = getDb();
-
-      // Verify ownership
-      const coffee = await db.execute({
-        sql: "SELECT * FROM coffees WHERE id = ? AND creator_id = ?",
-        args: [coffee_id, userId],
-      });
-      if (coffee.rows.length === 0) {
-        return { content: [{ type: "text", text: JSON.stringify({ error: "Coffee not found or you are not the creator" }) }] };
-      }
-
-      const fields: string[] = [];
-      const args: unknown[] = [];
-
-      if (updates.topic !== undefined) { fields.push("topic = ?"); args.push(updates.topic); }
-      if (updates.description !== undefined) { fields.push("description = ?"); args.push(updates.description); }
-      if (updates.city !== undefined) { fields.push("city = ?"); args.push(updates.city); }
-      if (updates.location !== undefined) { fields.push("location = ?"); args.push(updates.location); }
-      if (updates.scheduled_at !== undefined) { fields.push("scheduled_at = ?"); args.push(updates.scheduled_at); }
-      if (updates.max_size !== undefined) { fields.push("max_size = ?"); args.push(updates.max_size); }
-      if (updates.tags !== undefined) { fields.push("tags = ?"); args.push(JSON.stringify(updates.tags)); }
-
-      if (fields.length === 0) {
-        return { content: [{ type: "text", text: JSON.stringify({ error: "No fields to update" }) }] };
-      }
-
-      args.push(coffee_id);
-      await db.execute({
-        sql: `UPDATE coffees SET ${fields.join(", ")} WHERE id = ?`,
-        args: args as any[],
-      });
-
-      return { content: [{ type: "text", text: JSON.stringify({ success: true, message: "Coffee updated", updated_fields: fields.map(f => f.split(" =")[0]) }) }] };
+      if (!userId) return jsonResult({ error: "Authentication required" });
+      return jsonResult(await coffeeUpdate({ coffee_id, ...updates }, userId));
     }
   );
 
@@ -373,37 +108,8 @@ export function registerCoffeeTools(server: McpServer) {
     },
     async ({ coffee_id }, { authInfo }) => {
       const userId = (authInfo?.extra as { userId?: string })?.userId;
-      if (!userId) {
-        return { content: [{ type: "text", text: JSON.stringify({ error: "Authentication required" }) }] };
-      }
-
-      const db = getDb();
-
-      // Get coffee info before updating
-      const coffeeInfo = await db.execute({
-        sql: "SELECT topic FROM coffees WHERE id = ? AND creator_id = ?",
-        args: [coffee_id, userId],
-      });
-      if (coffeeInfo.rows.length === 0) {
-        return { content: [{ type: "text", text: JSON.stringify({ error: "Coffee not found or you are not the creator" }) }] };
-      }
-
-      await db.execute({
-        sql: "UPDATE coffees SET status = 'completed' WHERE id = ?",
-        args: [coffee_id],
-      });
-
-      // Notify all participants except creator
-      const participants = await db.execute({
-        sql: "SELECT user_id FROM coffee_participants WHERE coffee_id = ? AND user_id != ?",
-        args: [coffee_id, userId],
-      });
-      const topic = coffeeInfo.rows[0].topic as string;
-      for (const p of participants.rows) {
-        await createSystemMessage(p.user_id as string, `Coffee「${topic}」已完成，欢迎提交反馈`);
-      }
-
-      return { content: [{ type: "text", text: JSON.stringify({ success: true, message: "Coffee marked as completed" }) }] };
+      if (!userId) return jsonResult({ error: "Authentication required" });
+      return jsonResult(await coffeeComplete({ coffee_id }, userId));
     }
   );
 }

--- a/src/tools/message.ts
+++ b/src/tools/message.ts
@@ -1,15 +1,17 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { getDb } from "../db.js";
-import { generateId } from "../auth.js";
+import {
+  createSystemMessage,
+  messageSend,
+  messageInbox,
+  messageRead,
+} from "../services/message.js";
 
-/** Insert a system notification */
-export async function createSystemMessage(toUser: string, content: string): Promise<void> {
-  const db = getDb();
-  await db.execute({
-    sql: `INSERT INTO messages (id, type, from_user, to_user, content) VALUES (?, 'system', NULL, ?, ?)`,
-    args: [generateId("msg"), toUser, content],
-  });
+// Re-export for backward compatibility (used by coffee tools)
+export { createSystemMessage };
+
+function jsonResult(data: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
 }
 
 export function registerMessageTools(server: McpServer) {
@@ -24,103 +26,8 @@ export function registerMessageTools(server: McpServer) {
     },
     async (params, { authInfo }) => {
       const userId = (authInfo?.extra as { userId?: string })?.userId;
-      if (!userId) {
-        return { content: [{ type: "text", text: JSON.stringify({ error: "Authentication required" }) }] };
-      }
-
-      if (!params.to && !params.coffee_id) {
-        return { content: [{ type: "text", text: JSON.stringify({ error: "Either 'to' (nickname) or 'coffee_id' is required" }) }] };
-      }
-
-      const db = getDb();
-      const id = generateId("msg");
-
-      // Coffee group message
-      if (params.coffee_id) {
-        // Verify sender is a participant
-        const membership = await db.execute({
-          sql: "SELECT 1 FROM coffee_participants WHERE coffee_id = ? AND user_id = ?",
-          args: [params.coffee_id, userId],
-        });
-        if (membership.rows.length === 0) {
-          return { content: [{ type: "text", text: JSON.stringify({ error: "You are not a participant of this coffee" }) }] };
-        }
-
-        // Get coffee topic for response
-        const coffee = await db.execute({
-          sql: "SELECT topic FROM coffees WHERE id = ?",
-          args: [params.coffee_id],
-        });
-        if (coffee.rows.length === 0) {
-          return { content: [{ type: "text", text: JSON.stringify({ error: "Coffee not found" }) }] };
-        }
-
-        // Get participant count
-        const participants = await db.execute({
-          sql: "SELECT COUNT(*) as cnt FROM coffee_participants WHERE coffee_id = ?",
-          args: [params.coffee_id],
-        });
-
-        await db.execute({
-          sql: `INSERT INTO messages (id, type, from_user, coffee_id, content, reply_to)
-                VALUES (?, 'coffee', ?, ?, ?, ?)`,
-          args: [id, userId, params.coffee_id, params.content, params.reply_to || null],
-        });
-
-        return {
-          content: [{
-            type: "text",
-            text: JSON.stringify({
-              message_id: id,
-              type: "coffee",
-              coffee_id: params.coffee_id,
-              coffee_topic: coffee.rows[0].topic,
-              participants: participants.rows[0].cnt,
-              message: `Message sent to coffee group (${participants.rows[0].cnt} participants)`,
-            }),
-          }],
-        };
-      }
-
-      // Direct message
-      const recipient = await db.execute({
-        sql: "SELECT id FROM users WHERE LOWER(nickname) = LOWER(?) AND status = 'active'",
-        args: [params.to!],
-      });
-      if (recipient.rows.length === 0) {
-        return { content: [{ type: "text", text: JSON.stringify({ error: `User "${params.to}" not found` }) }] };
-      }
-
-      const toUserId = recipient.rows[0].id as string;
-      if (toUserId === userId) {
-        return { content: [{ type: "text", text: JSON.stringify({ error: "Cannot send message to yourself" }) }] };
-      }
-
-      await db.execute({
-        sql: `INSERT INTO messages (id, type, from_user, to_user, content, reply_to)
-              VALUES (?, 'direct', ?, ?, ?, ?)`,
-        args: [id, userId, toUserId, params.content, params.reply_to || null],
-      });
-
-      // Auto-generate system notification for recipient
-      const senderName = await db.execute({
-        sql: "SELECT nickname FROM users WHERE id = ?",
-        args: [userId],
-      });
-      const nickname = senderName.rows[0]?.nickname || "Someone";
-      await createSystemMessage(toUserId, `${nickname} 给你发了一条私信`);
-
-      return {
-        content: [{
-          type: "text",
-          text: JSON.stringify({
-            message_id: id,
-            type: "direct",
-            to: params.to,
-            message: `Message sent to ${params.to}`,
-          }),
-        }],
-      };
+      if (!userId) return jsonResult({ error: "Authentication required" });
+      return jsonResult(await messageSend(params, userId));
     }
   );
 
@@ -135,97 +42,8 @@ export function registerMessageTools(server: McpServer) {
     },
     async (params, { authInfo }) => {
       const userId = (authInfo?.extra as { userId?: string })?.userId;
-      if (!userId) {
-        return { content: [{ type: "text", text: JSON.stringify({ error: "Authentication required" }) }] };
-      }
-
-      const db = getDb();
-
-      // Build WHERE conditions
-      const conditions: string[] = [];
-      const args: unknown[] = [];
-
-      if (params.coffee_id) {
-        // Specific coffee messages
-        conditions.push("m.type = 'coffee' AND m.coffee_id = ?");
-        args.push(params.coffee_id);
-      } else if (params.type === "direct") {
-        conditions.push("m.type = 'direct' AND m.to_user = ?");
-        args.push(userId);
-      } else if (params.type === "system") {
-        conditions.push("m.type = 'system' AND m.to_user = ?");
-        args.push(userId);
-      } else if (params.type === "coffee") {
-        // All coffee messages where user is participant
-        conditions.push("m.type = 'coffee' AND m.coffee_id IN (SELECT coffee_id FROM coffee_participants WHERE user_id = ?)");
-        args.push(userId);
-      } else {
-        // All: direct to me + system to me + coffee groups I'm in
-        conditions.push(`(
-          (m.type = 'direct' AND m.to_user = ?) OR
-          (m.type = 'system' AND m.to_user = ?) OR
-          (m.type = 'coffee' AND m.coffee_id IN (SELECT coffee_id FROM coffee_participants WHERE user_id = ?))
-        )`);
-        args.push(userId, userId, userId);
-      }
-
-      // Exclude own coffee messages from inbox
-      conditions.push("NOT (m.type = 'coffee' AND m.from_user = ?)");
-      args.push(userId);
-
-      if (params.unread) {
-        conditions.push("mr.read_at IS NULL");
-      }
-
-      const whereClause = conditions.join(" AND ");
-
-      // Count unread
-      const unreadResult = await db.execute({
-        sql: `SELECT COUNT(*) as cnt FROM messages m
-              LEFT JOIN message_reads mr ON m.id = mr.message_id AND mr.user_id = ?
-              WHERE ${whereClause} AND mr.read_at IS NULL`,
-        args: [userId, ...args] as any[],
-      });
-
-      // Fetch messages
-      args.push(params.limit);
-      const result = await db.execute({
-        sql: `SELECT m.id, m.type, m.content, m.coffee_id, m.reply_to, m.created_at,
-                     u.nickname AS from_nickname,
-                     c.topic AS coffee_topic,
-                     CASE WHEN mr.read_at IS NOT NULL THEN 1 ELSE 0 END AS is_read
-              FROM messages m
-              LEFT JOIN users u ON m.from_user = u.id
-              LEFT JOIN coffees c ON m.coffee_id = c.id
-              LEFT JOIN message_reads mr ON m.id = mr.message_id AND mr.user_id = ?
-              WHERE ${whereClause}
-              ORDER BY m.created_at DESC
-              LIMIT ?`,
-        args: [userId, ...args] as any[],
-      });
-
-      const messages = result.rows.map((row) => ({
-        id: row.id,
-        type: row.type,
-        from: row.from_nickname || "system",
-        content: row.content,
-        coffee_id: row.coffee_id || undefined,
-        coffee_topic: row.coffee_topic || undefined,
-        reply_to: row.reply_to || undefined,
-        read: !!row.is_read,
-        created_at: row.created_at,
-      }));
-
-      return {
-        content: [{
-          type: "text",
-          text: JSON.stringify({
-            messages,
-            total: messages.length,
-            unread_count: unreadResult.rows[0].cnt,
-          }),
-        }],
-      };
+      if (!userId) return jsonResult({ error: "Authentication required" });
+      return jsonResult(await messageInbox(params, userId));
     }
   );
 
@@ -239,64 +57,8 @@ export function registerMessageTools(server: McpServer) {
     },
     async (params, { authInfo }) => {
       const userId = (authInfo?.extra as { userId?: string })?.userId;
-      if (!userId) {
-        return { content: [{ type: "text", text: JSON.stringify({ error: "Authentication required" }) }] };
-      }
-
-      if (!params.message_id && !params.coffee_id && !params.all) {
-        return { content: [{ type: "text", text: JSON.stringify({ error: "Specify message_id, coffee_id, or all: true" }) }] };
-      }
-
-      const db = getDb();
-      let marked = 0;
-
-      if (params.message_id) {
-        const result = await db.execute({
-          sql: `INSERT OR IGNORE INTO message_reads (message_id, user_id) VALUES (?, ?)`,
-          args: [params.message_id, userId],
-        });
-        marked = result.rowsAffected;
-      } else if (params.coffee_id) {
-        // Mark all unread coffee messages
-        const unread = await db.execute({
-          sql: `SELECT m.id FROM messages m
-                LEFT JOIN message_reads mr ON m.id = mr.message_id AND mr.user_id = ?
-                WHERE m.coffee_id = ? AND mr.read_at IS NULL`,
-          args: [userId, params.coffee_id],
-        });
-        for (const row of unread.rows) {
-          await db.execute({
-            sql: `INSERT OR IGNORE INTO message_reads (message_id, user_id) VALUES (?, ?)`,
-            args: [row.id, userId],
-          });
-        }
-        marked = unread.rows.length;
-      } else if (params.all) {
-        // Mark all unread messages (direct + system to me, coffee groups I'm in)
-        const unread = await db.execute({
-          sql: `SELECT m.id FROM messages m
-                LEFT JOIN message_reads mr ON m.id = mr.message_id AND mr.user_id = ?
-                WHERE mr.read_at IS NULL AND (
-                  (m.to_user = ?) OR
-                  (m.type = 'coffee' AND m.coffee_id IN (SELECT coffee_id FROM coffee_participants WHERE user_id = ?))
-                )`,
-          args: [userId, userId, userId],
-        });
-        for (const row of unread.rows) {
-          await db.execute({
-            sql: `INSERT OR IGNORE INTO message_reads (message_id, user_id) VALUES (?, ?)`,
-            args: [row.id, userId],
-          });
-        }
-        marked = unread.rows.length;
-      }
-
-      return {
-        content: [{
-          type: "text",
-          text: JSON.stringify({ success: true, marked_count: marked }),
-        }],
-      };
+      if (!userId) return jsonResult({ error: "Authentication required" });
+      return jsonResult(await messageRead(params, userId));
     }
   );
 }

--- a/src/tools/profile.ts
+++ b/src/tools/profile.ts
@@ -1,11 +1,15 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { getDb } from "../db.js";
 import {
-  generateToken,
-  generateId,
-  createInviteCodes,
-} from "../auth.js";
+  profileRegister,
+  profileGet,
+  profileUpdate,
+  adminCreateInviteCodes,
+} from "../services/profile.js";
+
+function jsonResult(data: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
+}
 
 export function registerProfileTools(server: McpServer) {
   server.tool(
@@ -15,34 +19,7 @@ export function registerProfileTools(server: McpServer) {
       nickname: z.string().describe("Your display name"),
       bio: z.string().describe("Self-introduction in natural language (skills, role, city, etc.)"),
     },
-    async ({ nickname, bio }) => {
-      const db = getDb();
-      const id = generateId("u");
-      const token = generateToken();
-
-      await db.execute({
-        sql: "INSERT INTO users (id, nickname, token, invite_code, status) VALUES (?, ?, ?, ?, 'active')",
-        args: [id, nickname, token, "open"],
-      });
-
-      await db.execute({
-        sql: "INSERT INTO profiles (user_id, bio) VALUES (?, ?)",
-        args: [id, bio],
-      });
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify({
-              user_id: id,
-              token,
-              message: "Registration successful. Save your token for future connections.",
-            }),
-          },
-        ],
-      };
-    }
+    async ({ nickname, bio }) => jsonResult(await profileRegister({ nickname, bio }))
   );
 
   server.tool(
@@ -51,34 +28,7 @@ export function registerProfileTools(server: McpServer) {
     {
       query: z.string().describe("User ID or nickname to look up"),
     },
-    async ({ query }, { authInfo }) => {
-      const db = getDb();
-      const result = await db.execute({
-        sql: `SELECT u.id, u.nickname, u.status, p.city, p.company, p.role, p.skills, p.bio, p.available, p.languages, p.updated_at
-              FROM users u LEFT JOIN profiles p ON u.id = p.user_id
-              WHERE u.id = ? OR u.nickname LIKE ?`,
-        args: [query, `%${query}%`],
-      });
-
-      if (result.rows.length === 0) {
-        return { content: [{ type: "text", text: JSON.stringify({ error: "User not found" }) }] };
-      }
-
-      const profiles = result.rows.map((row) => ({
-        user_id: row.id,
-        nickname: row.nickname,
-        status: row.status,
-        city: row.city,
-        company: row.company,
-        role: row.role,
-        skills: JSON.parse((row.skills as string) || "[]"),
-        bio: row.bio,
-        available: JSON.parse((row.available as string) || "[]"),
-        languages: JSON.parse((row.languages as string) || "[]"),
-      }));
-
-      return { content: [{ type: "text", text: JSON.stringify(profiles.length === 1 ? profiles[0] : profiles) }] };
-    }
+    async ({ query }) => jsonResult(await profileGet({ query }))
   );
 
   server.tool(
@@ -95,35 +45,8 @@ export function registerProfileTools(server: McpServer) {
     },
     async (params, { authInfo }) => {
       const userId = (authInfo?.extra as { userId?: string })?.userId;
-      if (!userId) {
-        return { content: [{ type: "text", text: JSON.stringify({ error: "Authentication required" }) }] };
-      }
-
-      const db = getDb();
-      const fields: string[] = [];
-      const values: unknown[] = [];
-
-      if (params.city !== undefined) { fields.push("city = ?"); values.push(params.city); }
-      if (params.company !== undefined) { fields.push("company = ?"); values.push(params.company); }
-      if (params.role !== undefined) { fields.push("role = ?"); values.push(params.role); }
-      if (params.skills !== undefined) { fields.push("skills = ?"); values.push(JSON.stringify(params.skills)); }
-      if (params.bio !== undefined) { fields.push("bio = ?"); values.push(params.bio); }
-      if (params.available !== undefined) { fields.push("available = ?"); values.push(JSON.stringify(params.available)); }
-      if (params.languages !== undefined) { fields.push("languages = ?"); values.push(JSON.stringify(params.languages)); }
-
-      if (fields.length === 0) {
-        return { content: [{ type: "text", text: JSON.stringify({ error: "No fields to update" }) }] };
-      }
-
-      fields.push("updated_at = CURRENT_TIMESTAMP");
-      values.push(userId);
-
-      await db.execute({
-        sql: `UPDATE profiles SET ${fields.join(", ")} WHERE user_id = ?`,
-        args: values as any[],
-      });
-
-      return { content: [{ type: "text", text: JSON.stringify({ success: true, message: "Profile updated" }) }] };
+      if (!userId) return jsonResult({ error: "Authentication required" });
+      return jsonResult(await profileUpdate(params, userId));
     }
   );
 
@@ -135,10 +58,7 @@ export function registerProfileTools(server: McpServer) {
     },
     async ({ count }, { authInfo }) => {
       const userId = (authInfo?.extra as { userId?: string })?.userId;
-      const codes = await createInviteCodes(count, userId || null);
-      return {
-        content: [{ type: "text", text: JSON.stringify({ codes, message: `Generated ${count} invite codes` }) }],
-      };
+      return jsonResult(await adminCreateInviteCodes({ count }, userId || null));
     }
   );
 }

--- a/vercel.json
+++ b/vercel.json
@@ -7,11 +7,15 @@
     },
     "api/index.ts": {
       "includeFiles": "src/**"
+    },
+    "api/rest.ts": {
+      "includeFiles": "src/**"
     }
   },
   "rewrites": [
     { "source": "/", "destination": "/api/index" },
-    { "source": "/mcp", "destination": "/api/mcp" }
+    { "source": "/mcp", "destination": "/api/mcp" },
+    { "source": "/api/rest/:path*", "destination": "/api/rest" }
   ],
   "crons": [
     {


### PR DESCRIPTION
## Summary
- **Service layer 重构**: 将 MCP tool handlers 中的业务逻辑抽取到 `src/services/`，MCP tools 和 REST API 共享同一套底层函数
- **REST API**: 新增 14 个 HTTP endpoint (`/api/rest/*`)，与 MCP tools 一一对应，支持 ChatGPT 等无法使用 MCP 的 chatbot 平台
- **OpenAPI 3.1 spec**: `GET /api/rest/openapi.json` 提供完整的 API 文档，可直接导入 ChatGPT GPTs/Actions

## REST API Endpoints

| Method | Endpoint | Auth | MCP Tool |
|--------|----------|------|----------|
| POST | `/api/rest/profile/register` | - | `profile_register` |
| GET | `/api/rest/profile?query=...` | - | `profile_get` |
| PUT | `/api/rest/profile` | Bearer | `profile_update` |
| POST | `/api/rest/admin/invite-codes` | Bearer | `admin_create_invite_codes` |
| POST | `/api/rest/coffee` | Bearer | `coffee_create` |
| GET | `/api/rest/coffee` | - | `coffee_list` |
| GET | `/api/rest/coffee/:id` | - | `coffee_detail` |
| PUT | `/api/rest/coffee/:id` | Bearer | `coffee_update` |
| POST | `/api/rest/coffee/:id/join` | Bearer | `coffee_join` |
| POST | `/api/rest/coffee/:id/leave` | Bearer | `coffee_leave` |
| POST | `/api/rest/coffee/:id/complete` | Bearer | `coffee_complete` |
| POST | `/api/rest/message` | Bearer | `message_send` |
| GET | `/api/rest/message/inbox` | Bearer | `message_inbox` |
| POST | `/api/rest/message/read` | Bearer | `message_read` |
| GET | `/api/rest/openapi.json` | - | — |

## Test plan
- [x] `npm run build` 通过
- [x] 本地 dev server 测试 REST 注册、查询、创建 coffee、认证拦截
- [x] OpenAPI spec 正确输出所有 endpoint
- [ ] Vercel 部署后验证 `/api/rest/*` 路由
- [ ] ChatGPT GPTs 导入 OpenAPI spec 测试

🤖 Generated with [Claude Code](https://claude.com/claude-code)