### PR TITLE
Add Data Coffee skill, setup guide, and MCP config helper

### DIFF
--- a/data-coffee/SKILL.md
+++ b/data-coffee/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: data-coffee
+description: Connect to the Data Coffee MCP community, including first-time setup, token registration, profile maintenance, coffee session discovery and creation, and member messaging. Use when Codex needs to configure the Data Coffee MCP endpoint, help a user join the community, or operate Data Coffee tools such as profile_register, coffee_list, coffee_create, coffee_join, or message_inbox.
+---
+
+# Data Coffee
+
+Connect to the Data Coffee MCP endpoint, complete first-run registration, and use the community tools without making the user manually reconstruct the workflow from the landing page.
+
+Use this skill as an MCP onboarding and operating guide. Keep the main flow short, then open [setup.md](./references/setup.md) when you need exact config snippets, prompts, or failure handling.
+
+## Quick start
+
+1. Check whether a `data-coffee` MCP server is already configured.
+2. If setup details are needed, open [setup.md](./references/setup.md).
+3. If the user has no token yet, register with `profile_register` using the user's nickname and a concise bio.
+4. Persist the returned token in the MCP config as `Authorization: Bearer <token>`.
+5. Ask the user to restart or reload the client if the client does not hot-reload MCP auth changes.
+6. After authentication works, use the Coffee and message tools for the user's actual goal.
+
+## Workflow
+
+### 1. Connect and verify
+
+- Prefer reusing an existing `data-coffee` config block instead of overwriting unrelated MCP settings.
+- Use `./scripts/render_mcp_config.py` when you need a clean JSON snippet with or without a token.
+- If the user is registering for the first time, gather only the minimum inputs required by the live tool: `nickname` and `bio`.
+- If registration succeeds, surface the token clearly and tell the user exactly where it must go.
+
+### 2. Operate the community tools
+
+- Profile:
+  - Use `profile_get` to inspect an existing member profile.
+  - Use `profile_update` only for fields the user actually wants to change.
+- Coffee sessions:
+  - Use `coffee_list` before recommending sessions.
+  - Use `coffee_detail` before `coffee_join` when the user asks about one specific session.
+  - Use `coffee_create` when the user wants to organize a meetup; gather topic, format, location, and time if missing.
+  - Use `coffee_update` or `coffee_complete` only when the user is the creator or explicitly managing their own session.
+- Messaging:
+  - Use `message_inbox` to review direct messages, coffee messages, or system notifications.
+  - Use `message_send` only after the user is clear about the recipient or target coffee.
+  - Use `message_read` after reviewing messages when the user wants inbox cleanup.
+
+### 3. Keep the interaction clean
+
+- Do not invent profile details, cities, schedules, or tags.
+- Do not claim registration is complete until the token is persisted and the client can use it.
+- If the MCP server is unreachable, separate client-config issues from remote-service issues.
+- If a tool requires authentication and returns an auth error, fall back to the setup flow instead of retrying blindly.
+
+## Reference map
+
+- Open [setup.md](./references/setup.md) for:
+  - exact MCP config JSON
+  - registration and token flow
+  - suggested prompts
+  - common troubleshooting
+
+- Use [render_mcp_config.py](./scripts/render_mcp_config.py) to generate a config block quickly.
+
+## Example requests
+
+- "Use $data-coffee to help me connect the MCP endpoint and register with nickname `Alex`."
+- "Use $data-coffee to check whether there are any Amsterdam coffee sessions this weekend."
+- "Use $data-coffee to draft and create a coffee about MLOps hiring in Rotterdam next Wednesday evening."
+- "Use $data-coffee to review my unread messages and mark them read after summarizing."

--- a/data-coffee/SKILL.md
+++ b/data-coffee/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: data-coffee
-description: Connect to the Data Coffee MCP community, including first-time setup, token registration, profile maintenance, coffee session discovery and creation, and member messaging. Use when Codex needs to configure the Data Coffee MCP endpoint, help a user join the community, or operate Data Coffee tools such as profile_register, coffee_list, coffee_create, coffee_join, or message_inbox.
+description: Connect to the Data Coffee MCP community, including first-time setup, token registration, profile maintenance, coffee session discovery and creation, and member messaging. Use when an AI agent needs to configure the Data Coffee MCP endpoint, help a user join the community, or operate Data Coffee tools such as profile_register, coffee_list, coffee_create, coffee_join, or message_inbox.
 ---
 
 # Data Coffee
@@ -36,6 +36,7 @@ Use this skill as an MCP onboarding and operating guide. Keep the main flow shor
   - Use `coffee_list` before recommending sessions.
   - Use `coffee_detail` before `coffee_join` when the user asks about one specific session.
   - Use `coffee_create` when the user wants to organize a meetup; gather topic, format, location, and time if missing.
+  - Use `coffee_leave` when the user wants to withdraw from a session they already joined.
   - Use `coffee_update` or `coffee_complete` only when the user is the creator or explicitly managing their own session.
 - Messaging:
   - Use `message_inbox` to review direct messages, coffee messages, or system notifications.

--- a/data-coffee/agents/openai.yaml
+++ b/data-coffee/agents/openai.yaml
@@ -1,0 +1,13 @@
+interface:
+  display_name: "Data Coffee"
+  short_description: "Connect to the Data Coffee MCP community"
+  default_prompt: "Use $data-coffee to connect to Data Coffee, register a profile, and browse or create coffee sessions."
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "data-coffee"
+      description: "Data Coffee community MCP server"
+      transport: "streamable_http"
+      url: "https://data-coffee.vercel.app/api/mcp"
+policy:
+  allow_implicit_invocation: true

--- a/data-coffee/references/setup.md
+++ b/data-coffee/references/setup.md
@@ -1,0 +1,100 @@
+# Data Coffee setup
+
+Use this page when you need exact MCP configuration, first-run registration steps, or quick recovery from auth and connectivity problems.
+
+## Endpoint
+
+- MCP endpoint: `https://data-coffee.vercel.app/api/mcp`
+
+## Config snippets
+
+Use `../scripts/render_mcp_config.py` to generate the snippet, or copy one of these directly.
+
+Without token yet:
+
+```json
+{
+  "mcpServers": {
+    "data-coffee": {
+      "type": "http",
+      "url": "https://data-coffee.vercel.app/api/mcp"
+    }
+  }
+}
+```
+
+With token:
+
+```json
+{
+  "mcpServers": {
+    "data-coffee": {
+      "type": "http",
+      "url": "https://data-coffee.vercel.app/api/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_TOKEN"
+      }
+    }
+  }
+}
+```
+
+## First-run flow
+
+1. Add the endpoint without a token.
+2. Connect or restart the client so the MCP server is visible.
+3. Register through the MCP tool with the minimum required inputs:
+   - `nickname`
+   - `bio`
+4. Copy the returned token into the MCP config as a bearer token.
+5. Restart or reload the client if needed.
+6. Verify authenticated tools by reading a profile or listing coffees.
+
+## Natural-language prompts
+
+- `帮我注册 data-coffee，昵称：<name>，自我介绍：<bio>`
+- `Help me register for data-coffee with nickname <name> and this bio: <bio>`
+- `Use $data-coffee to connect the MCP server and tell me exactly where to paste the token.`
+
+## Tool map
+
+- Profile:
+  - `profile_register`
+  - `profile_get`
+  - `profile_update`
+- Coffee:
+  - `coffee_list`
+  - `coffee_detail`
+  - `coffee_create`
+  - `coffee_join`
+  - `coffee_leave`
+  - `coffee_update`
+  - `coffee_complete`
+- Messages:
+  - `message_inbox`
+  - `message_send`
+  - `message_read`
+
+## Troubleshooting
+
+- `Authentication required`
+  - The MCP server is reachable, but the current request has no valid bearer token.
+  - Register first or update the token in config, then reload the client.
+- `Tool not found` or MCP server not visible
+  - The client did not load the `data-coffee` MCP server.
+  - Recheck the config shape and restart the client.
+- Network or connection failure
+  - Verify the endpoint URL exactly matches `https://data-coffee.vercel.app/api/mcp`.
+  - Treat this as a remote-service or connectivity problem, not a profile problem.
+
+## Operating hints
+
+- For session discovery, start with `coffee_list` and narrow down later.
+- For joining, inspect details first if the user cares about schedule, participants, or location.
+- For creating a session, gather missing fields instead of guessing:
+  - topic
+  - city or online
+  - location or meeting link
+  - time
+  - max size
+  - tags

--- a/data-coffee/references/setup.md
+++ b/data-coffee/references/setup.md
@@ -8,7 +8,11 @@ Use this page when you need exact MCP configuration, first-run registration step
 
 ## Config snippets
 
-Use `../scripts/render_mcp_config.py` to generate the snippet, or copy one of these directly.
+From the skill root, use `./scripts/render_mcp_config.py` to generate the snippet, or copy one of these directly.
+
+Prefer `DATA_COFFEE_TOKEN=... ./scripts/render_mcp_config.py` or pasting the token directly into the config file. Avoid `--token` on shared systems because command-line arguments can be exposed in shell history and process listings.
+
+These JSON examples are MCP server config snippets, so they use `"type": "http"`. The `agents/openai.yaml` example is a different agent-specific format and uses `transport: "streamable_http"` for the same endpoint.
 
 Without token yet:
 

--- a/data-coffee/scripts/render_mcp_config.py
+++ b/data-coffee/scripts/render_mcp_config.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+from typing import Any
 
 
 ENDPOINT = "https://data-coffee.vercel.app/api/mcp"
 
 
-def build_config(token: str | None, server_name: str) -> dict:
+def build_config(token: str | None, server_name: str) -> dict[str, Any]:
     server = {
         "type": "http",
         "url": ENDPOINT,
@@ -26,7 +28,7 @@ def main() -> int:
     )
     parser.add_argument(
         "--token",
-        help="Optional bearer token returned by profile_register",
+        help="Optional bearer token returned by profile_register; falls back to DATA_COFFEE_TOKEN",
     )
     parser.add_argument(
         "--server-name",
@@ -35,7 +37,9 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    config = build_config(args.token, args.server_name)
+    token = args.token or os.environ.get("DATA_COFFEE_TOKEN")
+
+    config = build_config(token, args.server_name)
     print(json.dumps(config, indent=2, ensure_ascii=False))
     return 0
 

--- a/data-coffee/scripts/render_mcp_config.py
+++ b/data-coffee/scripts/render_mcp_config.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Render a minimal Data Coffee MCP config snippet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+
+ENDPOINT = "https://data-coffee.vercel.app/api/mcp"
+
+
+def build_config(token: str | None, server_name: str) -> dict:
+    server = {
+        "type": "http",
+        "url": ENDPOINT,
+    }
+    if token:
+        server["headers"] = {"Authorization": f"Bearer {token}"}
+    return {"mcpServers": {server_name: server}}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Print a Data Coffee MCP config JSON snippet."
+    )
+    parser.add_argument(
+        "--token",
+        help="Optional bearer token returned by profile_register",
+    )
+    parser.add_argument(
+        "--server-name",
+        default="data-coffee",
+        help="MCP server key to emit in the JSON snippet",
+    )
+    args = parser.parse_args()
+
+    config = build_config(args.token, args.server_name)
+    print(json.dumps(config, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds a new `data-coffee` skill bundle for connecting Codex to the Data Coffee MCP community and guiding first-time setup and day-to-day usage.

## Main changes

- adds `data-coffee/SKILL.md` with the core workflow for:
  - configuring the MCP server
  - registering a profile and storing the returned token
  - using profile, coffee-session, and messaging tools safely
- adds `data-coffee/references/setup.md` with:
  - the Data Coffee MCP endpoint
  - copy-pasteable config snippets with and without auth
  - first-run registration steps
  - example prompts
  - troubleshooting guidance for auth, visibility, and connectivity issues
- adds `data-coffee/scripts/render_mcp_config.py`, a small helper that generates the MCP config JSON and optionally injects a bearer token and custom server name
- adds `data-coffee/agents/openai.yaml` so Data Coffee can be exposed as an agent with the MCP dependency and implicit invocation enabled

## Notes

This branch is focused on onboarding/configuration assets rather than modifying existing product behavior. The included helper script was verified to emit the expected config JSON both with and without a token.

## How does it improve UX?

Instead of asking user to install MCP, or let the users instruct their agents in their own way, with this agent skill and `skill-mgr` (https://github.com/AI-Colleagues/skill-mgr, to be published to Pypi soon), the users can:
1. Run `uvx skill-mgr install zhaidewei/data_coffee/data-coffee` to install the skill to supported agents (Claude Code, Codex, OpenClaw, and Orcheo etc., list is still growing)
2. In their agents, invoke the `data-coffee` skill to manage events

## Tests

Tested with Codex and Claude Code